### PR TITLE
materialize marts

### DIFF
--- a/transform/dbt_project.yml
+++ b/transform/dbt_project.yml
@@ -28,4 +28,12 @@ vars:
   # Date requested by Regan
   ga_data_start_date: "'2023-08-16'"
 
-models: {}
+models:
+  dse_snowflake:
+    staging:
+      +materialized: view
+    intermediate:
+      +materialized: view
+    marts:
+      +materialized: table
+      +database: "{{ env_var('DBT_ANALYTICS_DB', 'ANALYTICS_DEV') }}"

--- a/transform/models/marts/mart_br_widget.sql
+++ b/transform/models/marts/mart_br_widget.sql
@@ -1,0 +1,2 @@
+SELECT *
+FROM {{ ref('int_br_widget') }}


### PR DESCRIPTION
The BR dashboard is currently reading from Snowflake using `REPORTER_PRD`, which doesn't have access to raw data. Materialize marts as tables to get around this. A nightly build will need to be set up in the future but I'll manually keep things up to date for the time being until Ian gets back since admin privileges will be required on this repo.