### PR TITLE
Turn of processes flag in sqlfluff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,5 +32,5 @@ repos:
         description: "Lints sql files with `SQLFluff`"
         types: [sql]
         require_serial: true
-        entry: poetry run sqlfluff fix --show-lint-violations --processes 0 --nocolor --disable-progress-bar --force
+        entry: poetry run sqlfluff fix --show-lint-violations --nocolor --disable-progress-bar
         pass_filenames: true


### PR DESCRIPTION
Some systems don't seem to work well with the processes flag, so disable it. It's not needed for the functionality.

Follow-up to #65 